### PR TITLE
perf: reduce default compile footprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 
 ### 💼 Other
+- _perf_: make `ui` feature opt-in and reduce default compile footprint #95
 - _chore_: bump to v1.0.0-rc.7 #97
 - _chore_: bump to v1.0.0-rc.6 #77
 - fix: home stats: humanize the timestamp #67 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ web = ["dep:apalis-board-web"]
 actix = ["apalis-board-api/actix"]
 axum = ["apalis-board-api/axum"]
 events = ["apalis-board-api/sse"]
+ui = ["apalis-board-api/ui"]
 
 [dependencies]
 apalis-board-web = { path = "crates/web", version = "1.0.0-rc.7", optional = true }
@@ -31,7 +32,7 @@ all-features = true
 
 [workspace]
 members = ["crates/*", "examples/*"]
-default-members = [".", "crates/*"]
+default-members = [".", "crates/types", "crates/api"]
 resolver = "2"
 
 [workspace.package]

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -40,7 +40,7 @@ axum = { version = "0.8", optional = true, features = [
 ], default-features = false }
 
 [features]
-default = ["sse", "ui"]
+default = ["sse"]
 actix = ["dep:actix-web", "dep:actix-web-lab"]
 axum = ["dep:axum", "dep:thiserror"]
 sse = ["dep:tracing-core", "dep:tracing-subscriber"]

--- a/examples/actix-ntfy-service/Cargo.toml
+++ b/examples/actix-ntfy-service/Cargo.toml
@@ -13,12 +13,13 @@ apalis = { version = "1.0.0-rc.7", features = ["limit", "retry"] }
 apalis-sqlite = { features = ["migrate", "tokio-comp"], version = "1.0.0-rc.7" }
 apalis-board = { path = "../../", features = [
     "actix",
+    "ui",
 ] } # Replace path with version
 actix-web = "4.5.1"
 serde = "1"
 futures = "0.3"
 tower = "0.5"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["rt-multi-thread"] }
 log = "0.4"
 serde_json = "1"
 tracing-subscriber = { version = "0.3.11", features = ["json", "env-filter"] }

--- a/examples/axum-email-service/Cargo.toml
+++ b/examples/axum-email-service/Cargo.toml
@@ -15,11 +15,12 @@ apalis-postgres = { version = "1.0.0-rc.7", features = [
 ] }
 apalis-board = { path = "../../", features = [
     "axum",
+    "ui",
 ] } # Replace path with version
 serde = "1"
 futures = "0.3"
 tower = "0.5"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal"] }
 log = "0.4"
 serde_json = "1"
 tracing-subscriber = { version = "0.3.11", features = ["json", "env-filter"] }


### PR DESCRIPTION
## Description

Reduce compile times for consumers of `apalis-board` by making heavy optional
dependencies opt-in rather than on-by-default.

Three changes:

1. **Remove `ui` from `apalis-board-api` default features** — The `ui` feature
   pulls in `include_dir`, which embeds the entire built frontend `dist/`
   directory into the binary at compile time. Most consumers only want the API
   endpoints, not the bundled frontend. Consumers who need the embedded UI can
   enable the new `ui` feature on the root `apalis-board` crate.

2. **Exclude `crates/web` from `default-members`** — The Leptos CSR frontend is
   a WASM target intended to be built with Trunk, not `cargo build`. Including
   it in `default-members` via the `crates/*` glob caused every `cargo build`
   at the workspace root to compile the entire Leptos dependency tree
   (leptos, leptos_router, leptos_i18n, leptos-struct-table, web-sys, gloo,
   etc.) along with ~15 proc-macro crates. This is now skipped unless
   explicitly requested.

3. **Trim `tokio` features in examples** — Both examples used
   `features = ["full"]`, pulling in every tokio subsystem (process, signal, fs,
   io, net, etc.). Trimmed to only the features each example actually uses.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Performance improvement
- [ ] Refactoring (no functional changes)

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the existing tests and they pass
- [x] I have run `cargo fmt` and `cargo clippy`

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes

**Breaking change:** Consumers who depend on `apalis-board` (or `apalis-board-api`
directly) and use `ServeUI` will need to explicitly enable the `ui` feature.

Before:
```toml
apalis-board = { version = "1.0.0-rc.6", features = ["axum"] }
```

After:
```toml
apalis-board = { version = "1.0.0-rc.6", features = ["axum", "ui"] }
```

This is a semver-breaking change to `apalis-board-api`'s default features, but
the `ui` feature requires a pre-built `dist/` directory to exist at compile
time (via `include_dir!`), so it was not usable out-of-the-box on a fresh
clone anyway. Making it opt-in better reflects the actual build workflow.

Made with [Cursor](https://cursor.com)