### PR TITLE
refactor: centralize shared dependencies in workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 
 ### 💼 Other
+- _refactor_: centralize shared dependencies in `[workspace.dependencies]` #96
 - _chore_: bump to v1.0.0-rc.7 #97
 - _chore_: bump to v1.0.0-rc.6 #77
 - fix: home stats: humanize the timestamp #67 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ axum = ["apalis-board-api/axum"]
 events = ["apalis-board-api/sse"]
 
 [dependencies]
-apalis-board-web = { path = "crates/web", version = "1.0.0-rc.7", optional = true }
-apalis-board-api = { path = "crates/api", version = "1.0.0-rc.7", optional = true }
+apalis-board-web = { workspace = true, optional = true }
+apalis-board-api = { workspace = true, optional = true }
 
 [package.metadata.docs.rs]
 # defines the configuration attribute `docsrs`
@@ -38,6 +38,40 @@ resolver = "2"
 rust-version = "1.85"
 edition = "2024"
 repository = "https://github.com/apalis-dev/apalis-board"
+
+[workspace.dependencies]
+# Internal workspace crates
+apalis-board-types = { path = "crates/types", version = "1.0.0-rc.7" }
+apalis-board-api = { path = "crates/api", version = "1.0.0-rc.7" }
+apalis-board-web = { path = "crates/web", version = "1.0.0-rc.7" }
+
+# Apalis ecosystem
+apalis = "1.0.0-rc.7"
+apalis-core = "1.0.0-rc.7"
+apalis-sql = "1.0.0-rc.7"
+apalis-sqlite = "1.0.0-rc.7"
+apalis-postgres = "1.0.0-rc.7"
+
+# Serialization
+serde = "1"
+serde_json = "1"
+
+# Async runtime & utilities
+futures = "0.3"
+tower = "0.5"
+
+# Error handling
+thiserror = "2"
+
+# Web frameworks
+actix-web = "4.5.1"
+
+# Observability
+log = "0.4"
+tracing-subscriber = "0.3.20"
+
+# CLI
+clap = { version = "4.5.56", features = ["derive"] }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -17,26 +17,24 @@ publish = true
 
 [dependencies]
 apalis-core = { version = "1.0.0-rc.7", features = ["serde"] }
-apalis-board-types = { path = "../types", version = "1.0.0-rc.7" }
-serde = { version = "1", features = ["derive"] }
-futures = "0.3"
+apalis-board-types.workspace = true
+serde = { workspace = true, features = ["derive"] }
+futures.workspace = true
 tokio = { version = "1", default-features = false, features = ["sync"] }
-serde_json = "1"
+serde_json.workspace = true
 tracing-core = { version = "0.1.34", optional = true }
-tracing-subscriber = { version = "0.3.20", features = [
+tracing-subscriber = { workspace = true, features = [
     "json",
     "env-filter",
 ], optional = true }
 include_dir = { version = "0.7.4", optional = true }
-thiserror = { version = "2.0", optional = true }
-actix-web = { version = "4.5.1", optional = true }
+thiserror = { workspace = true, optional = true }
+actix-web = { workspace = true, optional = true }
 actix-web-lab = { version = "0.24.3", optional = true }
-
 axum = { version = "0.8", optional = true, features = [
     "json",
     "tokio",
     "query",
-
 ], default-features = false }
 
 [features]

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -17,8 +17,8 @@ publish = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
-thiserror = "2"
+serde = { workspace = true, features = ["derive"] }
+thiserror.workspace = true
 
 [package.metadata.docs.rs]
 # defines the configuration attribute `docsrs`

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -20,18 +20,18 @@ publish = true
 apalis-core = { version = "1.0.0-rc.7", features = [
     "serde",
 ], default-features = false }
-apalis-board-types = { path = "../types", version = "1.0.0-rc.7" }
-gloo-net = { version = "0.6" }
-serde_json = "1"
-serde = "1"
+apalis-board-types.workspace = true
+gloo-net = "0.6"
+serde_json.workspace = true
+serde.workspace = true
 leptos = { version = "0.8.9", features = ["csr"], default-features = false }
 leptos_router = "0.8.7"
 gloo-timers = { version = "0.3.0", features = ["futures"] }
-leptos-struct-table = { version = "0.17.0" }
+leptos-struct-table = "0.17.0"
 web-sys = "0.3"
 console_error_panic_hook = "0.1.7"
 chrono = { version = "0.4", features = ["serde"] }
-futures = "0.3"
+futures.workspace = true
 leptos_i18n = "0.6.0"
 leptos_meta = "0.8.5"
 

--- a/examples/actix-ntfy-service/Cargo.toml
+++ b/examples/actix-ntfy-service/Cargo.toml
@@ -8,19 +8,19 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 apalis-core = { version = "1.0.0-rc.7", features = ["serde"] }
-apalis-sql = { version = "1.0.0-rc.7" }
-apalis = { version = "1.0.0-rc.7", features = ["limit", "retry"] }
-apalis-sqlite = { features = ["migrate", "tokio-comp"], version = "1.0.0-rc.7" }
+apalis-sql.workspace = true
+apalis = { workspace = true, features = ["limit", "retry"] }
+apalis-sqlite = { workspace = true, features = ["migrate", "tokio-comp"] }
 apalis-board = { path = "../../", features = [
     "actix",
 ] } # Replace path with version
-actix-web = "4.5.1"
-serde = "1"
-futures = "0.3"
-tower = "0.5"
+actix-web.workspace = true
+serde.workspace = true
+futures.workspace = true
+tower.workspace = true
 tokio = { version = "1", features = ["full"] }
-log = "0.4"
-serde_json = "1"
-tracing-subscriber = { version = "0.3.11", features = ["json", "env-filter"] }
+log.workspace = true
+serde_json.workspace = true
+tracing-subscriber = { workspace = true, features = ["json", "env-filter"] }
 reqwest = { version = "0.13", features = ["json"] }
-clap = { version = "4.5.56", features = ["derive"] }
+clap.workspace = true

--- a/examples/axum-email-service/Cargo.toml
+++ b/examples/axum-email-service/Cargo.toml
@@ -6,24 +6,24 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 apalis-core = { version = "1.0.0-rc.7", features = ["serde"] }
-apalis = { version = "1.0.0-rc.7", features = ["limit", "retry"] }
-apalis-sql = { version = "1.0.0-rc.7" }
+apalis = { workspace = true, features = ["limit", "retry"] }
+apalis-sql.workspace = true
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres"] }
-apalis-postgres = { version = "1.0.0-rc.7", features = [
+apalis-postgres = { workspace = true, features = [
     "migrate",
     "tokio-comp",
 ] }
 apalis-board = { path = "../../", features = [
     "axum",
 ] } # Replace path with version
-serde = "1"
-futures = "0.3"
-tower = "0.5"
+serde.workspace = true
+futures.workspace = true
+tower.workspace = true
 tokio = { version = "1", features = ["full"] }
-log = "0.4"
-serde_json = "1"
-tracing-subscriber = { version = "0.3.11", features = ["json", "env-filter"] }
-clap = { version = "4.5.56", features = ["derive"] }
+log.workspace = true
+serde_json.workspace = true
+tracing-subscriber = { workspace = true, features = ["json", "env-filter"] }
+clap.workspace = true
 lettre = { version = "0.11.19", features = [
     "tracing",
     "builder",
@@ -31,7 +31,6 @@ lettre = { version = "0.11.19", features = [
     "tokio1",
     "tokio1-native-tls",
 ] }
-
 axum = { version = "0.8", features = ["json", "tokio", "query"] }
 rmp-serde = "1.3.0"
-thiserror = "2.0"
+thiserror.workspace = true


### PR DESCRIPTION
## Description

Add `[workspace.dependencies]` to the root `Cargo.toml` and update all
workspace members to inherit shared dependency versions via `workspace = true`.

This centralizes version management for:
- **Internal path crates** (`apalis-board-types`, `apalis-board-api`,
  `apalis-board-web`)
- **Apalis ecosystem** (`apalis`, `apalis-core`, `apalis-sql`, `apalis-sqlite`,
  `apalis-postgres`)
- **Shared third-party dependencies** (`serde`, `serde_json`, `futures`,
  `thiserror`, `tower`, `actix-web`, `tracing-subscriber`, `log`, `clap`)

Dependencies with conflicting `default-features` requirements across crates
(`tokio`, `axum`, `apalis-core`) are intentionally kept as direct dependencies,
since Cargo does not allow members to override the workspace-level
`default-features` setting.

This also standardizes `tracing-subscriber` to `0.3.20` across the workspace
(examples previously pinned `0.3.11`, which is semver-compatible).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring (no functional changes)

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the existing tests and they pass
- [x] I have run `cargo fmt` and `cargo clippy`

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes

This is a purely mechanical refactoring with no functional changes. All crate
resolution is identical — only the location where versions are specified has
moved from individual `Cargo.toml` files to the workspace root.

Future version bumps (e.g. apalis ecosystem releases) can now be done in a
single place rather than updating each member crate individually.

Made with [Cursor](https://cursor.com)